### PR TITLE
Kleine Verbesserungen für die Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all: git.chunked git.html
 git.txt: advanced.txt automatisierung.txt erste_schritte.txt gitdir.txt \
     github.txt grundlagen.txt installation.txt praxis.txt remote.txt \
     server.txt shell.txt vorwort.txt workflows.txt zusammenspiel.txt
+	touch $@
 
 git.html: git.txt asciidoc.conf
 	asciidoc -a numbered -a data-uri -a toclevels=3 $<
@@ -22,8 +23,10 @@ git.chunked-prereq: git.txt styles asciidoc.conf
 git.chunked: git.chunked-prereq styles/toc.html
 	a2x -f chunked --xsl-file styles/chunked.xsl --resource styles --stylesheet=gitbuch.css git.txt
 
-epub:
-	a2x -fepub --epubcheck git.txt
+epub: git.epub
+
+git.epub: git.txt
+	a2x -fepub --epubcheck $<
 
 clean:
 	rm -rf git.html git.chunked style/toc.html git.epub.d git.epub

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ git.chunked: git.chunked-prereq styles/toc.html
 	a2x -f chunked --xsl-file styles/chunked.xsl --resource styles --stylesheet=gitbuch.css git.txt
 
 epub:
-	a2x -dbook -fepub git.txt
-	epubcheck git.epub
+	a2x -fepub --epubcheck git.txt
 
 clean:
 	rm -rf git.html git.chunked style/toc.html git.epub.d git.epub


### PR DESCRIPTION
Hier 2 kleine Verbesserungen für die Makefile.
- a2x mit `--epubcheck` hat das den Vorteil, dass wenn epubcheck nicht vorhanden ist nur eine Warnung ausgegeben wird aber die Generierung trotzdem erfolgreich ist.
- Targets im Makefile sollten immer so heißen, wie die erzeugte Datei damit die Abhängigkeiten ausgewertet werden können. Das `touch` ist nötig, weil die Abhängigkeiten nicht rekursiv ausgewertet werden und man deshalb manuell `git.txt` aktualisieren muss damit die anderen Targets neu erstellt werden.
