### PR TITLE
PDF Generierung

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.xml
 git.chunked/
 *.epub
+git.pdf

--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,10 @@ epub:
 	a2x -dbook -fepub git.txt
 	epubcheck git.epub
 
+pdf: git.pdf
+
+git.pdf: git.txt
+	a2x -fpdf $<
+
 clean:
 	rm -rf git.html git.chunked style/toc.html git.epub.d git.epub

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,12 @@ epub:
 
 pdf: git.pdf
 
-git.pdf: git.txt
-	a2x -fpdf $<
+git.pdf: git.txt styles/dblatex.sty
+	a2x -fpdf --dblatex-opts "-P latex.output.revhistory=0 \
+                                  -P doc.publisher.show=0 \
+                                  -P latex.class.book=book \
+                                  -P geometry.options=margin=2cm \
+                                  -s styles/dblatex.sty" $<
 
 clean:
 	rm -rf git.html git.chunked style/toc.html git.epub.d git.epub

--- a/advanced.txt
+++ b/advanced.txt
@@ -28,10 +28,10 @@ Commit auf Basis eines anderen Knotens aufgebaut wird.  Die
 nachfolgenden Grafiken veranschaulichen die Funktionsweise:
 
 .Vor dem Rebase
-image::bilder_ebook/rebase-vorher.png[id="fig.rebase-vorher-dia",width="90%"]
+image::bilder_ebook/rebase-vorher.png[id="fig.rebase-vorher-dia",scaledwidth="90%"]
 
 .{empty}...und danach
-image::bilder_ebook/rebase-nachher.png[id="fig.rebase-nachher-dia",width="90%"]
+image::bilder_ebook/rebase-nachher.png[id="fig.rebase-nachher-dia",scaledwidth="90%"]
 
 In der einfachsten Form lautet das Kommando `git rebase
   <referenz>` (im o.g. Diagramm: `git rebase master`).  Damit
@@ -83,7 +83,7 @@ zweigt vom Commit ``fixed a bug...'' ab. Der
 Release 1.4.2 ist erschienen.
 
 .Vor dem Rebase
-image::bilder_ebook/screenshot-rebase-vorher.png[id="fig.screenshot-rebase-vorher",width="90%"]
+image::bilder_ebook/screenshot-rebase-vorher.png[id="fig.screenshot-rebase-vorher",scaledwidth="90%"]
 
 Nun wird `sqlite-support` ausgecheckt und neu auf
 `master` aufgebaut:
@@ -104,7 +104,7 @@ Rebase wendet die drei Änderungen, die durch Commits aus dem Branch
 folgt aus:
 
 .Nach Rebase
-image::bilder_ebook/screenshot-rebase-nachher.png[id="fig.screenshot-rebase-nachher",width="90%"]
+image::bilder_ebook/screenshot-rebase-nachher.png[id="fig.screenshot-rebase-nachher",scaledwidth="90%"]
 
 [[sec.rebase-extended]]
 ==== Erweiterte Syntax und Konflikte ==== 
@@ -382,7 +382,7 @@ Branches umsetzen, quasi ``transplantieren'' möchten?
 Betrachten Sie folgende Situation:
 
 .Vor dem `rebase --onto`
-image::bilder_ebook/rebase-onto-vorher.png[id="fig.rebase-onto-vorher-dia",width="90%"]
+image::bilder_ebook/rebase-onto-vorher.png[id="fig.rebase-onto-vorher-dia",scaledwidth="90%"]
 
 Sie haben gerade auf dem Branch `topic` ein Feature entwickelt,
 als Ihnen ein Fehler aufgefallen ist; Sie haben einen Branch
@@ -419,7 +419,7 @@ $ *git rebase --onto master topic bugfix*
 Das Ergebnis sieht aus wie erwartet:
 
 .Nach einem `rebase --onto`
-image::bilder_ebook/rebase-onto-nachher.png[id="fig.rebase-onto-nachher-dia",width="90%"]
+image::bilder_ebook/rebase-onto-nachher.png[id="fig.rebase-onto-nachher-dia",scaledwidth="90%"]
 
 [[sec.rebase-onto-ci-amend]]
 ==== Einen Commit verbessern ==== 
@@ -877,7 +877,7 @@ das grafische Tool `git gui blame` (hierfür müssen Sie
 gegebenenfalls das Paket `git-gui` installieren).
 
 .Ein Stück Code, das aus einer anderen Datei verschoben wurde
-image::bilder_ebook/git-gui-blame.png[id="fig.git-gui-blame",width="100%"]
+image::bilder_ebook/git-gui-blame.png[id="fig.git-gui-blame",scaledwidth="100%"]
 
 Wenn Sie eine Datei per `git gui blame <datei>` untersuchen,
 werden die unterschiedlichen Blöcke, die aus verschiedenen Commits
@@ -1377,7 +1377,7 @@ ein Stash in Gitk als Dreieck angezeigt, was im ersten Moment etwas
 verwirrend ist:
 
 .Ein Stash in Gitk
-image::bilder_ebook/stash-screenshot.png[id="fig.gitk-stash",width="90%"]
+image::bilder_ebook/stash-screenshot.png[id="fig.gitk-stash",scaledwidth="90%"]
 
 Mit dem Alias `git tree` (siehe <<rev-list>>) sieht das so aus:
 

--- a/automatisierung.txt
+++ b/automatisierung.txt
@@ -385,7 +385,7 @@ als das alte sind.
 
 
 .Die Ausgabe von `git diff` mit dem eigenen Diff-Programm `imgdiff`
-image::bilder_ebook/tux-diff.png[id="fig.tux-diff",width="90%"]
+image::bilder_ebook/tux-diff.png[id="fig.tux-diff",scaledwidth="90%"]
 
 Das Beispiel mit dem Tux inkl. Anleitung finden Sie auch in einem Repository
 unter: https://github.com/gitbuch/tux-diff-demo.

--- a/gitdir.txt
+++ b/gitdir.txt
@@ -34,7 +34,7 @@ Caching von CGit, <<sec.cgit-cache>>).
 
 
 .Die wichtigsten Einträge in `.git`
-image::bilder_ebook/git-dir-crop.png[id="fig.git-dir-listing",width="20%"]
+image::bilder_ebook/git-dir-crop.png[id="fig.git-dir-listing",scaledwidth="20%"]
 
 
 `logs/`:: Protokoll der Veränderungen an Referenzen; zugänglich über

--- a/github.txt
+++ b/github.txt
@@ -59,7 +59,7 @@ Mailinglisten -- dafür müssen Sie auf Alternativen ausweichen.
 
 
 .Github-Seite von Gollum
-image::bilder_ebook/github-gollum.png[id="fig.github-gollum",width="100%"]
+image::bilder_ebook/github-gollum.png[id="fig.github-gollum",scaledwidth="100%"]
 
 
 In <<fig.github-gollum>> sehen Sie einen Ausschnitt der
@@ -87,7 +87,7 @@ Integration-Manager-Workflow (siehe
 <<fig.developer-public-workflow>>).
 
 .Workflow bei Github
-image::bilder_ebook/github-workflow.png[id="fig.github-workflow",width="70%"]
+image::bilder_ebook/github-workflow.png[id="fig.github-workflow",scaledwidth="70%"]
 
 
 . Ein potentieller Contributor
@@ -136,7 +136,7 @@ eine grafische Darstellung der Forks mit noch ausstehenden Änderungen
 bereit, den sogenannten 'Network-Graph':
 
 .Der Github Network-Graph
-image::bilder_ebook/github-network.png[id="fig.github-network",width="100%"]
+image::bilder_ebook/github-network.png[id="fig.github-network",scaledwidth="100%"]
 
 Github bietet Ihnen unter 'Graphs' noch weitere Visualisierungen.
 Unter 'Languages' wird angezeigt, welche Programmiersprachen das
@@ -180,7 +180,7 @@ Herunterladen.  Wie Sie in <<fig.github-downloads>>
 sehen, sowohl als `tar.gz` als auch als `.zip` Archiv.
 
 .Aus Tags erstellte Downloads
-image::bilder_ebook/github-download.png[id="fig.github-downloads",width="65%"]
+image::bilder_ebook/github-download.png[id="fig.github-downloads",scaledwidth="65%"]
 
 
 
@@ -197,7 +197,7 @@ dargestellt, siehe <<fig.github-2up>>.  Auch Größenunterschiede sind
 ersichtlich.
 +
 .Modus '2-up'
-image::bilder_ebook/github-image-diff-2up.png[id="fig.github-2up",width="90%"]
+image::bilder_ebook/github-image-diff-2up.png[id="fig.github-2up",scaledwidth="90%"]
 
 
 'Swipe':: Das Bild wird in der Mitte geteilt. Links sehen Sie die alte
@@ -205,7 +205,7 @@ Version und rechts die neue. Schieben Sie den Regler hin und her, um
 die Änderungen zu beobachten.  Siehe <<fig.github-swipe>>.
 +
 .Modus 'Swipe' 
-image::bilder_ebook/github-image-diff-swipe.png[id="fig.github-swipe",width="90%"]
+image::bilder_ebook/github-image-diff-swipe.png[id="fig.github-swipe",scaledwidth="90%"]
 
 'Onion Skin':: Auch hier kommt ein Regler zum Einsatz, diesmal wird
 jedoch die neue Version eingeblendet, es entsteht also ein fließender

--- a/grundlagen.txt
+++ b/grundlagen.txt
@@ -47,7 +47,7 @@ löschen diese wieder; erst das Kommando `commit` überträgt die
 Datei, wie sie im Index vorgehalten wird, in das Repository (<<fig.index>>).
 
 .Kommandos `add`, `reset` und `commit`
-image::bilder_ebook/index.png[id="fig.index",width="90%"]
+image::bilder_ebook/index.png[id="fig.index",scaledwidth="90%"]
 
 Im Ausgangszustand, das heißt wenn `git status` die Nachricht
 `nothing to commit` ausgibt, sind Working Tree und Index mit
@@ -999,7 +999,7 @@ untersucht wird, mit dem Befehl `git clone
 git://github.com/gitbuch/objektmodell-beispiel.git` herunterladen.]
 
 .Hello World!-Programm in Python
-image::bilder_ebook/objektmodell-programm-crop.png[id="fig.objektmodell-program-crop",width="25%"]
+image::bilder_ebook/objektmodell-programm-crop.png[id="fig.objektmodell-program-crop",scaledwidth="25%"]
 
 Das Projekt besteht aus der Datei `hello.py` sowie einer
 `README`-Datei und einem Verzeichnis `test`. Führt man
@@ -1048,7 +1048,7 @@ Diese Eigenschaft wird als 'Kollisionssicherheit' bezeichnet.
 
 
 .SHA-1-Algorithmus
-image::bilder_ebook/sha.png[id="fig.sha",width="90%"]
+image::bilder_ebook/sha.png[id="fig.sha",scaledwidth="90%"]
 
 
 Allen Bemühungen der Kryptologen zum Trotz wurden vor einigen Jahren
@@ -1119,7 +1119,7 @@ referenziert, die diese Unterverzeichnisse abbilden.
 
 
 .Git-Objekte
-image::bilder_ebook/objekte.png[id="fig.objekte",width="90%"]
+image::bilder_ebook/objekte.png[id="fig.objekte",scaledwidth="90%"]
 
 
 Das Commit-Objekt enthält also genau 'eine' Referenz auf einen
@@ -1198,7 +1198,7 @@ zeigen, illustriert.
 
 
 .Hierarchische Beziehung der Git-Objekte
-image::bilder_ebook/objekte-zusammenhang.png[id="fig.objekte-zusammenhang",width="65%"]
+image::bilder_ebook/objekte-zusammenhang.png[id="fig.objekte-zusammenhang",scaledwidth="65%"]
 
 
 Jeder Commit referenziert den Top-Level Tree -- auch der Commit
@@ -1332,7 +1332,7 @@ gleichen.
 
 
 .Inhalt des Repositorys
-image::bilder_ebook/struktur.png[id="fig.struktur",width="80%"]
+image::bilder_ebook/struktur.png[id="fig.struktur",scaledwidth="80%"]
 
 
 Mehr noch: Eine Datei, die zweimal existiert, existiert nur einmal in
@@ -1423,7 +1423,7 @@ wurde. Commit G ist ein einzelner Commit, der noch nicht in den
 Hauptentwicklungszweig integriert wurde.
 
 .Ein Commit-Graph
-image::bilder_ebook/graph.png[id="fig.graph",width="45%"]
+image::bilder_ebook/graph.png[id="fig.graph",scaledwidth="45%"]
 
 Ein Resultat der Graph-Struktur ist die kryptographisch gesicherte
 'Integrität' eines Repositorys. Git referenziert durch die
@@ -1472,5 +1472,5 @@ Branches `master`, `HEAD`, `feature` und  `bugfix`.
 Sowie den Tags  `v0.1` und `v0.2`.
 
 .Ein beispielhafter Commit-Graph mit Branches und Tags
-image::bilder_ebook/graph-mit-refs.png[id="fig.graph-mit-refs",width="75%"]
+image::bilder_ebook/graph-mit-refs.png[id="fig.graph-mit-refs",scaledwidth="75%"]
 

--- a/praxis.txt
+++ b/praxis.txt
@@ -26,7 +26,7 @@ Branches werden als grüne Labels, Tags als gelbe Zeiger dargestellt.
 Für weitere Informationen siehe <<sec.gitk>>.
 
 .Das Beispiel-Repository aus <<ch.interna>> in Gitk. Zur Illustration wurde der zweite Commit mit  dem Tag `v0.1` versehen.
-image::bilder_ebook/gitk-basic.png[id="fig.gitk-basic",width="90%"]
+image::bilder_ebook/gitk-basic.png[id="fig.gitk-basic",scaledwidth="90%"]
 
 Da Branches in Git ``billig'' und Merges einfach sind, können
 Sie es sich leisten, Branches exzessiv zu verwenden.  Sie wollen etwas
@@ -77,7 +77,7 @@ Commits auf einem Branch erstellen -- sie bleiben also an der Spitze
 der Versionsgeschichte.
 
 .Der Branch referenziert immer den aktuellsten Commit
-image::bilder_ebook/commit.png[id="fig.commit",width="80%"]
+image::bilder_ebook/commit.png[id="fig.commit",scaledwidth="80%"]
 
 Branches in Repositories anderer Entwickler (z.B. der Master-Branch
 des offiziellen Repositorys), sog.
@@ -157,7 +157,7 @@ eine spezielle Bedeutung hat und Sie es durch Anführungszeichen oder
 mit einem Backslash schützen müssen.
 
 .Relative-Referenzen, `^` und `~<n>`
-image::bilder_ebook/relative-refs.png[id="fig.relative-refs",width="65%"]
+image::bilder_ebook/relative-refs.png[id="fig.relative-refs",scaledwidth="65%"]
 
 Die Syntax `<ref>~<n>` kommt einer
 'n'-fachen Wiederholung von `^` gleich:
@@ -466,7 +466,7 @@ während ein Lightweight Tag direkt auf das markierte Objekt zeigt.
 vergleichen Sie auch die anderen Git-Objekte, <<fig.objekte>>.
 
 .Das Tag-Objekt
-image::bilder_ebook/tags.png[id="fig.tag-objekt",width="90%"]
+image::bilder_ebook/tags.png[id="fig.tag-objekt",scaledwidth="90%"]
 
 Das gezeigte Tag-Objekt hat sowohl eine Größe (158 Byte) als auch eine
 SHA-1-Summe. Es enthält die Bezeichnung (`0.1`), den Objekt-Typ
@@ -527,7 +527,7 @@ Gitk stellt Tags als gelbe, pfeilartige Kästchen dar, die sich
 deutlich von den grünen, rechteckigen Branches unterscheiden:
 
 .Tags in Gitk
-image::bilder_ebook/tag-screenshot.png[id="fig.tag-gitk",width="90%"]
+image::bilder_ebook/tag-screenshot.png[id="fig.tag-gitk",scaledwidth="90%"]
 
 [[sec.lightweight-tags]]
 ===== Lightweight Tags =====  
@@ -710,7 +710,7 @@ der sich im Commit-Graphen sieben Commits nach der Version `1.7.1`
 befindet:
 
 .Der zu beschreibende Commit in Grau hervorgehoben
-image::bilder_ebook/describe-screenshot.png[id="fig.describe",width="90%"]
+image::bilder_ebook/describe-screenshot.png[id="fig.describe",scaledwidth="90%"]
 
 [subs="macros,quotes"]
 --------
@@ -1186,7 +1186,7 @@ verschmolzen werden.
 
 
 .Merge-Basis und Merge-Commit
-image::bilder_ebook/merge-base-commit.png[id="fig.merge-base-commit",width="70%"]
+image::bilder_ebook/merge-base-commit.png[id="fig.merge-base-commit",scaledwidth="70%"]
 
 
 Dafür geht Git so vor:footnote:[Die
@@ -1266,14 +1266,14 @@ Ein Fast-Forward-Merge tritt dann auf, wenn ein Branch, z.B.{empty}{nbsp}`topic`
 ist:
 
 .Vor dem 'Fast-Forward'-Merge
-image::bilder_ebook/ff-vorher.png[id="fig.merge-ff-before",width="90%"]
+image::bilder_ebook/ff-vorher.png[id="fig.merge-ff-before",scaledwidth="90%"]
 
 Ein einfaches `git merge topic` im Branch `master` führt
 nun dazu, dass `master` einfach weitergerückt wird -- es wird
 kein Merge-Commit erzeugt.
 
 .Nach dem 'Fast-Forward'-Merge – es wurde kein Merge-Commit erzeugt
-image::bilder_ebook/ff-nachher.png[id="fig.merge-ff-after",width="90%"]
+image::bilder_ebook/ff-nachher.png[id="fig.merge-ff-after",scaledwidth="90%"]
 
 Ein solches Verhalten geht natürlich nur dann, wenn die beiden
 Branches nicht divergiert haben, wenn also die Merge-Basis beider
@@ -1322,7 +1322,7 @@ folgenden Ausschnitte aus der Versionsgeschichte eines Projekts:
 
 
 .Integration eines Features mit und ohne Fast-Forward
-image::bilder_ebook/ff-no-ff-vergleich.png[id="fig.ff-vergleich",width="80%"]
+image::bilder_ebook/ff-no-ff-vergleich.png[id="fig.ff-vergleich",scaledwidth="80%"]
 
 Im oberen Fall können Sie nicht ohne weiteres erkennen, welche
 Commits ehemals im Branch `sha1-caching` entwickelt wurden,
@@ -1798,7 +1798,7 @@ Letzteres visualisiert besonders gut, wie sich eine Datei zwischen den
 Commits verändert hat.
 
 .Der Beispiel-Merge-Konflikt, im Merge-Tool ``Meld'' visualisiert
-image::bilder_ebook/meld-example.png[id="fig.meld",width="100%"]
+image::bilder_ebook/meld-example.png[id="fig.meld",scaledwidth="100%"]
 
 Sie starten ein solches Merge-Tool über `git mergetool`. Git wird alle
 Dateien, die Konflikte enthalten, durchgehen und jeweils (wenn Sie
@@ -2157,7 +2157,7 @@ untersuchen wir ein kleines Beispiel-Repository mit mehreren Branches,
 die untereinander gemergt wurden:
 
 .Der Graph der Commits, wie er in `gitk` dargestellt wird
-image::bilder_ebook/revision-list-commit-graph-gitk.png[id="fig.rev-list-graph",width="90%"]
+image::bilder_ebook/revision-list-commit-graph-gitk.png[id="fig.rev-list-graph",scaledwidth="90%"]
 
 Wir erkennen vier Branches (A-D) sowie einen Tag `release`.
 Diesen Baum können wir mit geeigneten Kommandozeilenoptionen auch per
@@ -2369,7 +2369,7 @@ einzelner Commits in einen anderen Branch (siehe auch
 <<sec.cherry-pick>>).
 
 .Komplizierte Topologie in Gitk
-image::bilder_ebook/gitk.png[id="fig.gitk",width="90%"]
+image::bilder_ebook/gitk.png[id="fig.gitk",scaledwidth="90%"]
 
 Gitk akzeptiert im wesentlichen die gleichen Optionen wie `git
   log`. Einige Beispiele:

--- a/remote.txt
+++ b/remote.txt
@@ -44,7 +44,7 @@ Repositories zum Einsatz kommen (<<sec.multi-remote>>),
 und den Patch-Austausch per E-Mail (<<sec.patch-queue>>).
 
 .Zentraler Workflow mit verteilter Versionsverwaltung
-image::bilder_ebook/zentral.png[id="fig.zentraler-workflow",width="70%"]
+image::bilder_ebook/zentral.png[id="fig.zentraler-workflow",scaledwidth="70%"]
 
 Im Unterschied zu zentralen Systemen erfolgen die Commit- und
 Checkout-Vorgänge bei Git lokal.  Auch andere alltägliche Aufgaben,
@@ -300,7 +300,7 @@ initialisiert Git für jeden Remote-Branch einen
 Remote-Tracking-Branch.
 
 .Erzeugte Remote-Tracking-Branches
-image::bilder_ebook/clone.png[id="fig.clone",width="100%"]
+image::bilder_ebook/clone.png[id="fig.clone",scaledwidth="100%"]
 
 
 In <<fig.clone>> sehen Sie ein Beispiel. Das
@@ -377,7 +377,7 @@ dem Präfix `remotes/<remote-name>/` angezeigt, das zudem dunkelgelb
 gefärbt ist (<<fig.remote-tracking-gitk>>).
 
 .Branch `next` und der entsprechende Remote-Tracking-Branch in Gitk
-image::bilder_ebook/remote-tracking-gitk.png[id="fig.remote-tracking-gitk",width="90%"]
+image::bilder_ebook/remote-tracking-gitk.png[id="fig.remote-tracking-gitk",scaledwidth="90%"]
 
 [[sec.git_fetch]]
 === Commits herunterladen === 
@@ -438,7 +438,7 @@ lädt Git den fehlenden Commit C herunter und setzt anschließend den
 Remote-Tracking-Branch darauf.
 
 .Remote-Tracking-Branches werden aktualisiert
-image::bilder_ebook/fetch.png[id="fig.fetch",width="90%"]
+image::bilder_ebook/fetch.png[id="fig.fetch",scaledwidth="90%"]
 
 [[sec.refspec]]
 ===== Refspec =====  
@@ -676,7 +676,7 @@ integriert, was Sie an dem Merge-Commit M sowie der
 aktuellen Position des lokalen `master` erkennen.
 
 .Was bei einem Pull passiert
-image::bilder_ebook/pull.png[id="fig.pull",width="90%"]
+image::bilder_ebook/pull.png[id="fig.pull",scaledwidth="90%"]
 
 Alternativ weist die Option `--rebase` das Pull-Kommando an, nach dem
 `fetch` den lokalen Branch per Rebase auf den
@@ -692,7 +692,7 @@ Sie statt des Standard-Merge einen Rebase ausführen.
 
 
 .Was bei einem Pull mit Rebase passiert
-image::bilder_ebook/pull_rebase.png[id="fig.pull_rebase",width="90%"]
+image::bilder_ebook/pull_rebase.png[id="fig.pull_rebase",scaledwidth="90%"]
 
 
 Die Ausgangssituation ist dieselbe wie in 
@@ -976,7 +976,7 @@ entspricht. Außerdem wird der Remote-Tracking-Branch
 Remote widerspiegelt.
 
 .Referenzen und Commits hochladen
-image::bilder_ebook/push.png[id="fig.push",width="100%"]
+image::bilder_ebook/push.png[id="fig.push",scaledwidth="100%"]
 
 Analog zu `fetch` weigert sich Git, Referenzen zu aktualisieren,
 bei denen der Ziel-Commit kein Nachfahre des aktuellen Commits ist:
@@ -1282,7 +1282,7 @@ eigene Entwicklungsmaschine zu geben, das geschieht in der Praxis aber
 beinahe nie.
 
 .Integration-Manager Workflow
-image::bilder_ebook/developer-public.png[id="fig.developer-public-workflow",width="70%"]
+image::bilder_ebook/developer-public.png[id="fig.developer-public-workflow",scaledwidth="70%"]
 
 Einer der Maintainer, die Zugriff auf das Haupt-Repository haben,
 überprüft dann, ob der Code funktioniert, ob er den
@@ -1603,7 +1603,7 @@ Nummerierung und der Commit-Message und enden auf
   die Auswahl von dem Commit bis zum `HEAD`.
 
 .Drei Commits nach  `master` als Patches formatieren
-image::bilder_ebook/gitk-screen-format-patch.png[id="fig.gitk-screen-format-patch",width="90%"]
+image::bilder_ebook/gitk-screen-format-patch.png[id="fig.gitk-screen-format-patch",scaledwidth="90%"]
 
 <<fig.gitk-screen-format-patch>> zeigt die
 Ausgangssituation. Wir wollen die drei Commits in dem Branch
@@ -1762,7 +1762,7 @@ angezeigt:footnote:[Sie sehen in
 
 
 .Patch-Serie als Mail-Thread
-image::bilder_ebook/mail-thread.png[id="fig.mail-thread",width="100%"]
+image::bilder_ebook/mail-thread.png[id="fig.mail-thread",scaledwidth="100%"]
 
 Das Kommando können Sie über Optionen -- beispielsweise `--to`, `--from` und `--cc` -- anpassen (siehe die Man-Page `git-send-email(1)`).  Die
 unbedingt benötigten Angaben werden aber, sofern nicht angegeben,
@@ -1933,7 +1933,7 @@ wiederum alle Mitstreiter synchronisieren.
 
 
 .Workflow: 'Dictator and Lieutenants'
-image::bilder_ebook/patches-per-mail.png[id="fig.dictator",width="90%"]
+image::bilder_ebook/patches-per-mail.png[id="fig.dictator",scaledwidth="90%"]
 
 Der Workflow basiert auf Vertrauen: Der Diktator vertraut seinen
 Lieutenants und übernimmt deren weitergeleitete Modifikationen meist

--- a/server.txt
+++ b/server.txt
@@ -1165,10 +1165,10 @@ $HTTP["host"] =~ "^git\.example\.com(:\d+)?$" {
 
 
 .Übersichtsseite von Gitweb
-image::bilder_ebook/gitweb-overview.png[id="fig.gitweb-overview",width="90%"]
+image::bilder_ebook/gitweb-overview.png[id="fig.gitweb-overview",scaledwidth="90%"]
 
 .Darstellung eines Commits in Gitweb
-image::bilder_ebook/gitweb-commitdiff.png[id="fig.gitweb-commitdiff",width="90%"]
+image::bilder_ebook/gitweb-commitdiff.png[id="fig.gitweb-commitdiff",scaledwidth="90%"]
 
 
 
@@ -1219,7 +1219,7 @@ zu verwenden, so dass Sie das Paket ggf. leicht wieder loswerden
 können.
 
 .Übersichtsseite von CGit
-image::bilder_ebook/cgit-overview.png[id="fig.cgit-overview",width="90%"]
+image::bilder_ebook/cgit-overview.png[id="fig.cgit-overview",scaledwidth="90%"]
 
 
 [[sec.cgit-integration]]
@@ -1354,7 +1354,7 @@ scan-path=/var/git/repositories
 
 
 .Darstellung eines Commits in CGit
-image::bilder_ebook/cgit-commitdiff.png[id="fig.cgit-commitdiff",width="90%"]
+image::bilder_ebook/cgit-commitdiff.png[id="fig.cgit-commitdiff",scaledwidth="90%"]
 
 
 [[sec.cgit-special-config]]

--- a/styles/dblatex.sty
+++ b/styles/dblatex.sty
@@ -1,0 +1,27 @@
+%%
+%% This style is derived from the docbook one.
+%%
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{asciidoc}[2008/06/05 AsciiDoc DocBook Style]
+%% Just use the original package and pass the options.
+\RequirePackageWithOptions{docbook}
+
+% Sidebar is a boxed minipage that can contain verbatim.
+% Changed shadow box to double box.
+\renewenvironment{sidebar}[1][0.95\textwidth]{
+  \hspace{0mm}\newline%
+  \noindent\begin{Sbox}\begin{minipage}{#1}%
+  \setlength\parskip{\medskipamount}%
+}{
+  \end{minipage}\end{Sbox}\doublebox{\TheSbox}%
+}
+
+% For DocBook literallayout elements, see `./dblatex/dblatex-readme.txt`.
+\usepackage{alltt}
+
+\pagestyle{fancy}
+\fancyhf{}
+\fancyhead[RO,LE]{\thepage}
+\fancyhead[LO]{\leftmark}
+\fancyhead[RE]{\rightmark}
+\renewcommand{\footrulewidth}{0pt}

--- a/workflows.txt
+++ b/workflows.txt
@@ -176,7 +176,7 @@ Punkte umfassenden Workflows, der unten detailliert erläutert wird.
 
 
 .Branch-Modell gemäß `gitworkflows (7)`
-image::bilder_ebook/branch-model.png[id="fig.branch-model",width="90%"]
+image::bilder_ebook/branch-model.png[id="fig.branch-model",scaledwidth="90%"]
 
 . Neue Topic-Branches entstehen von
   wohldefinierten Punkten, z.B. getaggten Releases, auf dem

--- a/zusammenspiel.txt
+++ b/zusammenspiel.txt
@@ -152,7 +152,7 @@ Folgt das Projekt dem Subversion-Standardlayout
 Argument `--stdlayout` bzw.  kurz `-s`.
 
 .Standardlayout Subversion
-image::bilder_ebook/svn-stdlayout-crop.png[id="fig.svn-stdlayout",width="20%"]
+image::bilder_ebook/svn-stdlayout-crop.png[id="fig.svn-stdlayout",scaledwidth="20%"]
 
 [[sec.git-svn-metadata]]
 ===== SVN-Metadaten =====  
@@ -215,7 +215,7 @@ passen Sie den Aufruf von `git svn` entsprechend an: Statt
 Projekte in einem Subversion-Repository verwaltet werden (<<fig.svn-nonstdlayout>>).
 
 .Non-Standard Layout
-image::bilder_ebook/svn-nonstdlayout-crop.png[id="fig.svn-nonstdlayout",width="20%"]
+image::bilder_ebook/svn-nonstdlayout-crop.png[id="fig.svn-nonstdlayout",scaledwidth="20%"]
 
 Um `projekt1` zu konvertieren, würde der Aufruf wie folgt
 lauten:footnote:[Existieren
@@ -298,12 +298,12 @@ Angenommen, das Subversion-Repository hat folgende Subversion-Branches
 und -Tags:
 
 .Beispiel Subversion-Branches und -Tags
-image::bilder_ebook/svn-branches-crop.png[id="fig.svn-branches",width="20%"]
+image::bilder_ebook/svn-branches-crop.png[id="fig.svn-branches",scaledwidth="20%"]
 
 In diesem Fall erzeugt `git svn` folgende Git-Branches:
 
 .Konvertierte Git-Branches
-image::bilder_ebook/git-branches-crop.png[id="fig.git-konverted-branches",width="35%"]
+image::bilder_ebook/git-branches-crop.png[id="fig.git-konverted-branches",scaledwidth="35%"]
 
 Das Präfix passen Sie mit der Option `--prefix=` an. So
 werden zum Beispiel mit der Anweisung `--prefix=svn/` alle
@@ -398,10 +398,10 @@ Das Script `git-convert-refs` übersetzt schließlich
 Lightweight Tag.
 
 .Konvertierte Branches und Tags vor der Übersetzung
-image::bilder_ebook/git-convert-refs-before.png[id="fig.git-convert-refs-before",width="90%"]
+image::bilder_ebook/git-convert-refs-before.png[id="fig.git-convert-refs-before",scaledwidth="90%"]
 
 .Konvertierte Branches und Tags nach der Übersetzung
-image::bilder_ebook/git-convert-refs-after.png[id="fig.git-convert-refs-after",width="90%"]
+image::bilder_ebook/git-convert-refs-after.png[id="fig.git-convert-refs-after",scaledwidth="90%"]
 
 
 Nachdem Sie die Subversion-Branches und Tags umgeschrieben haben,
@@ -460,7 +460,7 @@ Veränderungen. Das Tag `v2.0` hingegen wurde nach seiner
 Erstellung von Commit `C2` nochmals verändert.
 
 .Konvertierte Git-Tags auf Abzweigungen
-image::bilder_ebook/git-svn-tag-fix-before.png[id="fig.git-svn-tag-fix-before",width="90%"]
+image::bilder_ebook/git-svn-tag-fix-before.png[id="fig.git-svn-tag-fix-before",scaledwidth="90%"]
 
 In <<fig.git-svn-tag-fix-after>> sehen Sie, wie das Tag
 `v1.0` von obigem Script auf den Vorfahren verschoben wurde
@@ -469,7 +469,7 @@ Ort und Stelle (weil die Trees aufgrund nachträglicher Veränderungen
 verschieden sind).
 
 .Tag `v1.0` wurde umgeschrieben
-image::bilder_ebook/git-svn-tag-fix-after.png[id="fig.git-svn-tag-fix-after",width="90%"]
+image::bilder_ebook/git-svn-tag-fix-after.png[id="fig.git-svn-tag-fix-after",scaledwidth="90%"]
 
 
 [TIP]
@@ -547,7 +547,7 @@ unten abgebildet.
 
 
 .Konvertiertes Subversion-Repository
-image::bilder_ebook/git-svn-merge-demo.png[id="fig.git-svn-merge-demo",width="90%"]
+image::bilder_ebook/git-svn-merge-demo.png[id="fig.git-svn-merge-demo",scaledwidth="90%"]
 
 Die Commits im Subversion-Repository wurden in der folgenden
 Reihenfolge gemacht:
@@ -837,7 +837,7 @@ aktuelle Branch (in diesem Fall `master`) neu aufgebaut. Der
 Commit D&#39; kann nun hochgeladen werden.
 
 .`git svn rebase` integriert die neu hinzugekommene Subversion-Revision als Commit  `C` – vor `D`, was dadurch zu `D'` wird.
-image::bilder_ebook/svn_rebase.png[id="fig.git-svn-rebase",width="90%"]
+image::bilder_ebook/svn_rebase.png[id="fig.git-svn-rebase",scaledwidth="90%"]
 
 Mit `git svn dcommit` laden Sie das Changeset eines Git-Commits
 als Revision in das Subversion-Repository hoch. Als Teil der Operation
@@ -851,7 +851,7 @@ ist.
 
 
 .Nach einem `git svn dcommit` hat der Commit `D'` eine neue SHA-1-ID und wird zu  `D''`, weil seine Commit-Beschreibung verändert wurde, um Metainformationen abzuspeichern.
-image::bilder_ebook/svn_dcommit.png[id="fig.git-svn-dcommit",width="90%"]
+image::bilder_ebook/svn_dcommit.png[id="fig.git-svn-dcommit",scaledwidth="90%"]
 
 Ähnlich wie bei `git push` dürfen Sie keine Commits, die Sie
 bereits mit `git svn dcommit` hochgeladen haben, nachträglich


### PR DESCRIPTION
Mit `make pdf` kann man jetzt die PDF Version des Buches erzeugen. `dblatex` muss dafür installiert sein.

In der `README.md` hab ich noch nichts dazu geschrieben.
