### PR TITLE
Zeilenumbruch in pre-Tags ermöglichen (insbesondere fürs ebook)

### DIFF
--- a/styles/gitbuch.css
+++ b/styles/gitbuch.css
@@ -170,6 +170,7 @@ body pre {
   margin: 0.5em 1em 0.5em 1em !important;
   line-height: 1.0;
   color: navy;
+  white-space: pre-wrap;
 }
 
 tt.literal, code.literal {


### PR DESCRIPTION
Bei einem schmalen Ausschnitt werden die Inhalte der pre-Tags nicht umgebrochen, was insbesondere bei der EPub-Version dazu führt, dass diese auf einem ebook-Reader nicht vollständig lesbar sind.
Durch die Ergänzung von `white-space: pre-wrap;` im Stylesheet für `body pre` werden Zeilenumbrüche in diesen Tags ermöglicht.