### PR TITLE
Zeilenumbruch in pre-Tags ermöglichen (fürs ebook)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ git.chunked: git.chunked-prereq styles/toc.html
 epub: git.epub
 
 git.epub: git.txt
-	a2x -fepub --epubcheck $<
+	a2x -fepub --stylesheet="docbook-xsl.css styles/ebook.css" --epubcheck $<
 
 pdf: git.pdf
 

--- a/styles/ebook.css
+++ b/styles/ebook.css
@@ -1,0 +1,3 @@
+body pre {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
Durch das einbinden des zusätzlichen Stylesheets werden im EPub Zeilenumbrüche in pre-Tags ermöglicht. Die Lesbarkeit war vorher auf einem handelsüblichen ebook-Reader eingeschränkt, da viele Codezeilen länger sind als darstellbar.